### PR TITLE
Opening name uniqueness controllable for different views

### DIFF
--- a/app/app_helpers.py
+++ b/app/app_helpers.py
@@ -54,7 +54,9 @@ def timeline_page(player_id: str):
 
 def opening_strength_page(player_id: str):
     """Creates the opening strength page with the table of opening strengths"""
-    df = Transformer.to_opening_strength(st.session_state.trees[player_id])
+    df = Transformer.tree_to_opening_strength(
+        st.session_state.trees[player_id], unique_names=True
+    )
 
     col1, col2 = st.columns(2)
 
@@ -90,7 +92,9 @@ def opening_strength_page(player_id: str):
 
 def single_opening_page(player_id):
     """Creates the single opening page"""
-    df = Transformer.to_opening_strength(st.session_state.trees[player_id])
+    df = Transformer.tree_to_opening_strength(
+        st.session_state.trees[player_id], unique_names=False
+    )
 
     opening_families = sorted(
         set(

--- a/tests/openings/test_transformers.py
+++ b/tests/openings/test_transformers.py
@@ -65,9 +65,9 @@ def test_tree_to_timeline():
 
     assert isinstance(timeline.index, pd.MultiIndex)
     assert timeline.index.names == ["name", "move", "colour"]
-    assert timeline.index.levels[0].tolist() == ["King's pawn [1]", "Neo-Grünfeld Defense [2]"]  # type: ignore
+    assert timeline.index.levels[0].tolist() == ["King's pawn", "Neo-Grünfeld Defense"]  # type: ignore
     assert (
-        timeline.loc[("Neo-Grünfeld Defense [2]", 6, "Black")][datetime(2022, 12, 31)]
+        timeline.loc[("Neo-Grünfeld Defense", 6, "Black")][datetime(2022, 12, 31)]
         == 2.0
     )
 
@@ -75,7 +75,7 @@ def test_tree_to_timeline():
 def test_tree_to_opening_strength():
     tree = load_tree()
 
-    opening_strength = Transformer.to_opening_strength(tree)
+    opening_strength = Transformer.tree_to_opening_strength(tree, unique_names=True)
 
     assert opening_strength.shape == (3, 4)
     assert opening_strength.columns.tolist() == [
@@ -96,5 +96,32 @@ def test_tree_to_opening_strength():
     )
     assert (
         opening_strength.loc[(("Neo-Grünfeld Defense [2]", 6, "Black"))]["mean_results"]
+        == 0.50
+    )
+
+
+def test_tree_to_opening_strength_2():
+    tree = load_tree()
+
+    opening_strength = Transformer.tree_to_opening_strength(tree, unique_names=False)
+
+    assert opening_strength.shape == (3, 4)
+    assert opening_strength.columns.tolist() == [
+        "occurrence",
+        "mean_following_game_scores",
+        "mean_results",
+        "mean_score_in_n_moves",
+    ]
+    assert (
+        opening_strength.loc[(("Neo-Grünfeld Defense", 6, "Black"))]["occurrence"] == 2
+    )
+    assert (
+        opening_strength.loc[(("Neo-Grünfeld Defense", 6, "Black"))][
+            "mean_following_game_scores"
+        ]
+        == 0.31
+    )
+    assert (
+        opening_strength.loc[(("Neo-Grünfeld Defense", 6, "Black"))]["mean_results"]
         == 0.50
     )


### PR DESCRIPTION
## What this PR does
- to improve the UI, controlling whether index is used to ensure the uniqueness of opening names (this is not necessary on the single opening page because of additional controls)
- test added